### PR TITLE
Fix images references

### DIFF
--- a/4/php7/debian9/apache/Dockerfile
+++ b/4/php7/debian9/apache/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/cloud-marketplace-ops/php7-apache:7.3-debian9
+FROM marketplace.gcr.io/google/php7-apache2:7.3
 
 # install the PHP extensions we need
 RUN set -ex; \

--- a/5/php7/debian9/apache/Dockerfile
+++ b/5/php7/debian9/apache/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/cloud-marketplace-ops/php7-apache:7.3-debian9
+FROM marketplace.gcr.io/google/php7-apache2:7.3
 
 # install the PHP extensions we need
 RUN set -ex; \

--- a/5/php7/debian9/fpm/Dockerfile
+++ b/5/php7/debian9/fpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/cloud-marketplace-ops/php7-fpm:7.3-debian9
+FROM marketplace.gcr.io/google/php7-apache2:7.3
 
 # install the PHP extensions we need
 RUN set -ex; \

--- a/exporter/Dockerfile
+++ b/exporter/Dockerfile
@@ -1,4 +1,4 @@
-FROM gcr.io/google-appengine/debian9:latest as exporter-builder
+FROM marketplace.gcr.io/google/debian9:latest as exporter-builder
 
 ENV GOPATH /usr/local
 ENV GOROOT /usr/local/go
@@ -41,7 +41,7 @@ RUN set -eux \
     # Verifies checksum. Changing the checksum means changing the licenses.
     && echo "${NOTICES_SHA256} /NOTICES" | sha256sum -c
 
-FROM gcr.io/google-appengine/debian9:latest
+FROM marketplace.gcr.io/google/debian9:latest
 
 COPY --from=exporter-builder /apache_exporter /bin/apache_exporter
 COPY --from=exporter-builder /NOTICES /usr/share/apache_exporter/NOTICES

--- a/versions.yaml
+++ b/versions.yaml
@@ -32,7 +32,7 @@ versions:
     repo: 'wordpress5-php7-apache'
     templateSubDir: debian9
     tags: *tags
-    from: 'gcr.io/cloud-marketplace-ops/php7-apache:7.3-debian9'
+    from: 'marketplace.gcr.io/google/php7-apache2:7.3'
     templateArgs:
       cmd: 'apache2-foreground'
       c2dRelease: '5.3.2'
@@ -46,7 +46,7 @@ versions:
     repo: 'wordpress5-php7-fpm'
     templateSubDir: debian9
     tags: *tags
-    from: 'gcr.io/cloud-marketplace-ops/php7-fpm:7.3-debian9'
+    from: 'marketplace.gcr.io/google/php7-apache2:7.3'
     templateArgs:
       cmd: 'php-fpm'
       c2dRelease: '5.3.2'
@@ -65,7 +65,7 @@ versions:
     - '4.9.12-debian9'
     - '4.9.12'
     - 'latest'
-    from: 'gcr.io/cloud-marketplace-ops/php7-apache:7.3-debian9'
+    from: 'marketplace.gcr.io/google/php7-apache2:7.3'
     templateArgs:
       cmd: 'apache2-foreground'
       c2dRelease: '4.9.12'
@@ -83,7 +83,7 @@ versions:
     tags:
     - 'exporter'
     - 'exporter-0.5.0'
-    from: gcr.io/google-appengine/debian9:latest
+    from: marketplace.gcr.io/google/debian9:latest
     templateArgs:
       exporter_notices_check_sum: '28baca3649151b2b68f5d4e1b07d225c99b435e3f59d3d4e9b6e19d747c3d8d2'
     packages:


### PR DESCRIPTION
Previously used images based on `cloud-marketplace-ops` GCP project was not publicly accessible for end-users. 